### PR TITLE
Fix crash on startup if step is zero

### DIFF
--- a/src/main/java/io/github/sjouwer/gammautils/compat/SodiumConfigBuilder.java
+++ b/src/main/java/io/github/sjouwer/gammautils/compat/SodiumConfigBuilder.java
@@ -19,7 +19,7 @@ public class SodiumConfigBuilder implements ConfigEntryPoint {
         }
 
         int step = gamma.getStep();
-        if (min % step != 0 || max % step != 0) {
+        if (step == 0 || min % step != 0 || max % step != 0) {
             step = 1;
         }
 


### PR DESCRIPTION
Found out when fiddling with the config:
```
---- Minecraft Crash Report ----
// Don't do that.

Time: 2026-06-30 19:54:41
Description: Mod 'gammautils' failed while registering config options.

java.lang.ArithmeticException: / by zero
	at knot//io.github.sjouwer.gammautils.compat.SodiumConfigBuilder.registerConfigLate(SodiumConfigBuilder.java:22)
	at knot//net.caffeinemc.mods.sodium.client.config.ConfigManager.registerConfigs(ConfigManager.java:93)
	at knot//net.caffeinemc.mods.sodium.client.config.ConfigManager.registerConfigsLate(ConfigManager.java:76)
	at knot//net.minecraft.client.Minecraft.handler$eei000$sodium$postInit(Minecraft.java:21167)
	at knot//net.minecraft.client.Minecraft.onGameLoadFinished(Minecraft.java)
	at knot//net.minecraft.client.Minecraft.onResourceLoadFinished(Minecraft.java:806)
	at knot//net.minecraft.client.Minecraft.handler$eab000$rrls$init(Minecraft.java:20719)
	at knot//net.minecraft.client.Minecraft.<init>(Minecraft.java:767)
	at java.base/java.lang.Thread.run(Thread.java:1474)
```